### PR TITLE
Replace val functions with def

### DIFF
--- a/src/main/scala/Cipher/Ascii.scala
+++ b/src/main/scala/Cipher/Ascii.scala
@@ -10,7 +10,7 @@ protected trait Ascii {
     val LowerCase, UpperCase, NonLetter = Value
   }
 
-  val charType: (Char) => CharType.Value = (c: Char) => {
+  def charType(c: Char): CharType.Value = {
     if (lowerLetters.contains(c))
       CharType.LowerCase
     else if (upperLetters.contains(c))
@@ -34,7 +34,7 @@ protected trait Ascii {
     int.toChar
   }
 
-  private val asciiShiftAmount = (t: CharType.Value) => {
+  private def asciiShiftAmount(t: CharType.Value): Int = {
     if (t == CharType.LowerCase) 97
     else if (t == CharType.UpperCase) 65
     else 0

--- a/src/main/scala/Cipher/Cipher.scala
+++ b/src/main/scala/Cipher/Cipher.scala
@@ -22,11 +22,13 @@ protected trait Cipher {
 
   def decrypt(m: Message, k: Key): Message
 
-  val encrypt: (Char, Int, Int) => Char =
-    (c: Char, shift: Int, alphabetSize: Int) => Math.floorMod(c + shift, alphabetSize).toChar
-  val decrypt: (Char, Int, Int) => Char =
-    (c: Char, shift: Int, alphabetSize: Int) => Math.floorMod(c - shift, alphabetSize).toChar
-  val convertKey: (Char, Int, Int) => Char =
-    (c: Char, shift: Int, alphabetSize: Int) => (Math.floorMod(c, alphabetSize) + 1).toChar
+  def encrypt(c: Char, shift: Int, alphabetSize: Int): Char =
+    Math.floorMod(c + shift, alphabetSize).toChar
+
+  def decrypt(c: Char, shift: Int, alphabetSize: Int): Char =
+    Math.floorMod(c - shift, alphabetSize).toChar
+
+  def convertKey(c: Char, shift: Int, alphabetSize: Int): Char =
+    (Math.floorMod(c, alphabetSize) + 1).toChar
 
 }


### PR DESCRIPTION
It's often seen as better practice to always use def for function definitions, even though you can use val. The consistency helps, and it's quicker to parse that it's a function rather than a variable.